### PR TITLE
Add DB Liveness probe

### DIFF
--- a/architect.yml
+++ b/architect.yml
@@ -88,7 +88,7 @@ services:
         port: ${{ secrets.db_port }}
         protocol: postgresql
     liveness_probe:
-      command: pg_isready -d ${{ secrets.db_name }}
+      command: pg_isready -d ${{ secrets.db_name }} -U ${{ secrets.db_user }}
       interval: 10s
       failure_threshold: 3
     environment:

--- a/architect.yml
+++ b/architect.yml
@@ -43,7 +43,7 @@ services:
       PORT: *port
       DB_NAME: ${{ secrets.db_name }}
       DB_USER: ${{ secrets.db_user }}
-      DB_PASSWORD:  ${{ secrets.db_pass }}
+      DB_PASSWORD: ${{ secrets.db_pass }}
       DB_HOST: ${{ services.app-db.interfaces.database.host }}
       DB_PORT: ${{ services.app-db.interfaces.database.port }}
     # We want our app to start up after the db is running so that we can connect to it on startup!
@@ -68,7 +68,7 @@ services:
         '
       build:
         args:
-          DEBUG: '1'
+          DEBUG: "1"
       volumes:
         # The name of the volume we are creating
         app:
@@ -76,7 +76,6 @@ services:
           host_path: ./server
           # The `WORKDIR` defined in the Dockerfile, where we want our code to be mounted
           mount_path: /usr/src
-
 
   #  This is an additional service that adds a postgres database
   #   to show off Architect's support for microservice architecture
@@ -88,6 +87,10 @@ services:
       database:
         port: ${{ secrets.db_port }}
         protocol: postgresql
+    liveness_probe:
+      command: pg_isready -d ${{ secrets.db_name }}
+      interval: 10s
+      failure_threshold: 3
     environment:
       POSTGRES_DB: ${{ secrets.db_name }}
       POSTGRES_USER: ${{ secrets.db_user }}


### PR DESCRIPTION
Right now this doesn't help with much, but once https://gitlab.com/architect-io/architect-cli/-/issues/629 is completed, this will cause the app to start _after_ the database is ready, which fixes an issue starting this project in an empty environment where the app starts before the db and isn't available until the healthcheck fails and it gets restarted